### PR TITLE
Restore original window config after zoom-window-next

### DIFF
--- a/zoom-window.el
+++ b/zoom-window.el
@@ -319,8 +319,7 @@ PERSP: the perspective to be killed."
         (current-buf (current-buffer)))
     (zoom-window--restore-mode-line-face)
     (zoom-window--restore-window-configuration)
-    (unless (string= (buffer-name current-buf) (buffer-name))
-      (switch-to-buffer current-buf))
+    (pop-to-buffer current-buf)
     (zoom-window--goto-line current-line)
     (move-to-column current-column)))
 


### PR DESCRIPTION
One way to address #19 but I'm not sure that the behavior produced by this change is actually the desired behavior. It works for me, though.

This is a very minor fix. I hope it's okay that I didn't create a dedicated feature branch.

